### PR TITLE
Feature/init rework

### DIFF
--- a/SKMenuDrawerViewController.xcodeproj/project.pbxproj
+++ b/SKMenuDrawerViewController.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		14416D2D1F0D35A300E0065C /* SKMenuDrawerViewController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14416D231F0D35A300E0065C /* SKMenuDrawerViewController.framework */; };
 		14416D441F0D35C500E0065C /* SKMenuDrawerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 14416D3F1F0D35C500E0065C /* SKMenuDrawerViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		14D1EEC01F0FDCDC005781E4 /* MenuViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1EEBF1F0FDCDC005781E4 /* MenuViewControllerProtocol.swift */; };
+		14D1EEC21F0FDE27005781E4 /* MockMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1EEC11F0FDE27005781E4 /* MockMenuViewController.swift */; };
 		14F6923B1F0D4DB500564955 /* MenuDrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F6923A1F0D4DB500564955 /* MenuDrawerViewController.swift */; };
 		14F692B11F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F692B01F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift */; };
 		14F692B31F0DB66700564955 /* MockMenuDrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F692B21F0DB66700564955 /* MockMenuDrawerViewController.swift */; };
@@ -35,6 +37,8 @@
 		14416D3E1F0D35C500E0065C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14416D3F1F0D35C500E0065C /* SKMenuDrawerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKMenuDrawerViewController.h; sourceTree = "<group>"; };
 		14416D411F0D35C500E0065C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		14D1EEBF1F0FDCDC005781E4 /* MenuViewControllerProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewControllerProtocol.swift; sourceTree = "<group>"; };
+		14D1EEC11F0FDE27005781E4 /* MockMenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMenuViewController.swift; sourceTree = "<group>"; };
 		14F6923A1F0D4DB500564955 /* MenuDrawerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuDrawerViewController.swift; sourceTree = "<group>"; };
 		14F692B01F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuDrawerViewControllerSpec.swift; sourceTree = "<group>"; };
 		14F692B21F0DB66700564955 /* MockMenuDrawerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMenuDrawerViewController.swift; sourceTree = "<group>"; };
@@ -104,6 +108,7 @@
 			children = (
 				14416D3E1F0D35C500E0065C /* Info.plist */,
 				14F6923A1F0D4DB500564955 /* MenuDrawerViewController.swift */,
+				14D1EEBF1F0FDCDC005781E4 /* MenuViewControllerProtocol.swift */,
 				14416D3F1F0D35C500E0065C /* SKMenuDrawerViewController.h */,
 				14F692C41F0E87D400564955 /* UIViewController.swift */,
 			);
@@ -116,6 +121,7 @@
 				14416D411F0D35C500E0065C /* Info.plist */,
 				14F692B01F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift */,
 				14F692B21F0DB66700564955 /* MockMenuDrawerViewController.swift */,
+				14D1EEC11F0FDE27005781E4 /* MockMenuViewController.swift */,
 				14F692C91F0E8D3A00564955 /* MockUIViewController.swift */,
 				14F692C71F0E8CF100564955 /* UIViewControllerSpec.swift */,
 			);
@@ -345,6 +351,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14F6923B1F0D4DB500564955 /* MenuDrawerViewController.swift in Sources */,
+				14D1EEC01F0FDCDC005781E4 /* MenuViewControllerProtocol.swift in Sources */,
 				14F692C51F0E87D400564955 /* UIViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -357,6 +364,7 @@
 				14F692CB1F0E8D3E00564955 /* UIViewControllerSpec.swift in Sources */,
 				14F692CA1F0E8D3A00564955 /* MockUIViewController.swift in Sources */,
 				14F692B11F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift in Sources */,
+				14D1EEC21F0FDE27005781E4 /* MockMenuViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleApp/SampleApp/Application/AppDelegate.swift
+++ b/SampleApp/SampleApp/Application/AppDelegate.swift
@@ -8,11 +8,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        let contentViewController = ContentViewController()
-        let contentNavigationController = NavigationController(rootViewController: contentViewController)
         let menuViewController = MenuViewController()
-        let menuNavigationController = UINavigationController(rootViewController: menuViewController)
-        let rootViewController = MenuDrawerViewController(contentViewController: contentNavigationController, menuViewController: menuNavigationController)
+        let rootViewController = MenuDrawerViewController(menuViewController: menuViewController)
         self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()
 

--- a/SampleApp/SampleApp/ViewControllers/MenuViewController.swift
+++ b/SampleApp/SampleApp/ViewControllers/MenuViewController.swift
@@ -1,11 +1,25 @@
 import Foundation
+import SKMenuDrawerViewController
 import SKTableViewDataSource
 import UIKit
 
-class MenuViewController: UIViewController {
+class MenuViewController: UIViewController, MenuViewControllerProtocol {
 
     var dataSource: TableViewDataSource<String>?
     @IBOutlet weak var tableView: UITableView!
+
+    func initialContentViewController() -> UIViewController {
+        let indexPath = IndexPath(row: 0, section: 0)
+
+        return viewControllerForIndexPath(indexPath)
+    }
+
+    func viewControllerForIndexPath(_ indexPath: IndexPath) -> UIViewController {
+        let viewController = ContentViewController()
+        let navigationController = NavigationController(rootViewController: viewController)
+
+        return navigationController
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,10 +36,8 @@ class MenuViewController: UIViewController {
 
 extension MenuViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let viewController = ContentViewController()
-        let navigationController = NavigationController(rootViewController: viewController)
+        let navigationController = viewControllerForIndexPath(indexPath)
         parent?.setRootContentViewController(navigationController)
-
         parent?.toggleMenu()
     }
 }

--- a/SampleApp/SampleApp/ViewControllers/MenuViewController.xib
+++ b/SampleApp/SampleApp/ViewControllers/MenuViewController.xib
@@ -21,21 +21,30 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="26L-6j-kMb">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="bQD-3f-cuZ"/>
                     </connections>
                 </tableView>
+                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dCO-av-6GN">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                    <items>
+                        <navigationItem id="6tb-Nk-K9S"/>
+                    </items>
+                </navigationBar>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="26L-6j-kMb" firstAttribute="top" secondItem="JwL-2s-Gac" secondAttribute="top" id="KXS-dQ-ZvC"/>
+                <constraint firstItem="dCO-av-6GN" firstAttribute="leading" secondItem="JwL-2s-Gac" secondAttribute="leading" id="3q7-gH-wq3"/>
+                <constraint firstAttribute="trailing" secondItem="dCO-av-6GN" secondAttribute="trailing" id="Go4-xb-eC9"/>
                 <constraint firstItem="26L-6j-kMb" firstAttribute="leading" secondItem="JwL-2s-Gac" secondAttribute="leading" id="MyG-Gs-jiL"/>
                 <constraint firstAttribute="trailing" secondItem="26L-6j-kMb" secondAttribute="trailing" id="PoQ-lN-DWc"/>
                 <constraint firstAttribute="bottom" secondItem="26L-6j-kMb" secondAttribute="bottom" id="cOr-gw-Cqf"/>
+                <constraint firstItem="26L-6j-kMb" firstAttribute="top" secondItem="dCO-av-6GN" secondAttribute="bottom" id="oDh-XH-Kct"/>
+                <constraint firstItem="dCO-av-6GN" firstAttribute="top" secondItem="JwL-2s-Gac" secondAttribute="top" id="v5W-kw-E6u"/>
             </constraints>
-            <point key="canvasLocation" x="-86" y="-185"/>
+            <point key="canvasLocation" x="-86.5" y="-185.5"/>
         </view>
     </objects>
 </document>

--- a/Source/MenuDrawerViewController.swift
+++ b/Source/MenuDrawerViewController.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-open class MenuDrawerViewController: UIViewController {
+open class MenuDrawerViewController<T: UIViewController>: UIViewController where T: MenuViewControllerProtocol {
 
     // MARK: Static Variables
 
-    static let animationDuration = 0.25
+    let animationDuration = 0.25
 
-    static let menuWidthPercentage: CGFloat = 0.75
+    let menuWidthPercentage: CGFloat = 0.75
 
     // MARK: Internal Variables
 
@@ -24,8 +24,8 @@ open class MenuDrawerViewController: UIViewController {
 
     // MARK: Initializers
 
-    public init(contentViewController: UIViewController, menuViewController: UIViewController) {
-        self.contentViewController = contentViewController
+    public init(menuViewController: T) {
+        self.contentViewController = menuViewController.initialContentViewController()
         self.menuViewController = menuViewController
 
         super.init(nibName: nil, bundle: nil)
@@ -44,7 +44,7 @@ open class MenuDrawerViewController: UIViewController {
 
     open override func toggleMenu() {
         menuIsOpen = !menuIsOpen
-        let duration = MenuDrawerViewController.animationDuration
+        let duration = animationDuration
         animateBackgroundDim(duration: duration)
         view.setNeedsLayout()
 
@@ -98,7 +98,7 @@ open class MenuDrawerViewController: UIViewController {
     }
 
     func fadeFrom(_ fromViewController: UIViewController, to toViewController: UIViewController) {
-        UIView.animate(withDuration: MenuDrawerViewController.animationDuration, animations: {
+        UIView.animate(withDuration: animationDuration, animations: {
             fromViewController.view.alpha = 0.0
         }) { [weak self] (_) in
             fromViewController.view.removeFromSuperview()
@@ -109,7 +109,7 @@ open class MenuDrawerViewController: UIViewController {
     }
 
     func menuWidth() -> CGFloat {
-        return ceil(view.frame.width * MenuDrawerViewController.menuWidthPercentage)
+        return ceil(view.frame.width * menuWidthPercentage)
     }
 
     // MARK: UIViewController Methods

--- a/Source/MenuViewControllerProtocol.swift
+++ b/Source/MenuViewControllerProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol MenuViewControllerProtocol {
+    func initialContentViewController() -> UIViewController
+}

--- a/Tests/MenuDrawerViewControllerSpec.swift
+++ b/Tests/MenuDrawerViewControllerSpec.swift
@@ -6,25 +6,23 @@ import Quick
 
 class MenuDrawerViewControllerSpec: QuickSpec {
     override func spec() {
-        var unitUnderTest: MenuDrawerViewController!
+        var unitUnderTest: MenuDrawerViewController<MockMenuViewController>!
 
         describe("MenuDrawerViewController") {
             context("init(contentViewController:menuViewController:)") {
-                var contentViewController: UIViewController!
-                var menuViewController: UIViewController!
+                var menuViewController: MockMenuViewController!
 
                 beforeEach {
-                    contentViewController = UIViewController()
-                    menuViewController = UIViewController()
-                    unitUnderTest = MenuDrawerViewController(contentViewController: contentViewController, menuViewController: menuViewController)
-                }
-
-                it("Should set the content view controller") {
-                    expect(unitUnderTest.contentViewController).to(be(contentViewController))
+                    menuViewController = MockMenuViewController()
+                    unitUnderTest = MenuDrawerViewController(menuViewController: menuViewController)
                 }
 
                 it("Should set the menu view controller") {
                     expect(unitUnderTest.menuViewController).to(be(menuViewController))
+                }
+
+                it("Should call initialContentViewController on the menu view controller") {
+                    expect(menuViewController.initialContentViewControllerCalled).to(beTrue())
                 }
             }
 
@@ -41,7 +39,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
 
             context("setRootContentViewController(_:)") {
                 beforeEach {
-                    unitUnderTest = MockMenuDrawerViewController(contentViewController: UIViewController(), menuViewController: UIViewController())
+                    unitUnderTest = MockMenuDrawerViewController(menuViewController: MockMenuViewController())
                     unitUnderTest.setRootContentViewController(UIViewController())
                 }
 
@@ -55,11 +53,11 @@ class MenuDrawerViewControllerSpec: QuickSpec {
             }
 
             context("toggleMenu()") {
-                var menuViewController: UIViewController!
+                var menuViewController: MockMenuViewController!
 
                 beforeEach {
-                    menuViewController = UIViewController()
-                    unitUnderTest = MenuDrawerViewController(contentViewController: UIViewController(), menuViewController: menuViewController)
+                    menuViewController = MockMenuViewController()
+                    unitUnderTest = MenuDrawerViewController(menuViewController: menuViewController)
                     expect(unitUnderTest.view).toNot(beNil())
                     unitUnderTest.viewDidLoad()
                     unitUnderTest.view.layoutIfNeeded()
@@ -76,7 +74,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
                 var viewController: UIViewController!
 
                 beforeEach {
-                    unitUnderTest = MenuDrawerViewController(contentViewController: UIViewController(), menuViewController: UIViewController())
+                    unitUnderTest = MenuDrawerViewController(menuViewController: MockMenuViewController())
                     viewController = UIViewController()
                     unitUnderTest.addContentViewController(viewController)
                 }
@@ -94,7 +92,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
                 var viewController: UIViewController!
 
                 beforeEach {
-                    unitUnderTest = MenuDrawerViewController(contentViewController: UIViewController(), menuViewController: UIViewController())
+                    unitUnderTest = MenuDrawerViewController(menuViewController: MockMenuViewController())
                     viewController = UIViewController()
                     unitUnderTest.addMenuViewController(viewController)
                 }
@@ -115,7 +113,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
                 beforeEach {
                     fromViewController = UIViewController()
                     toViewController = UIViewController()
-                    unitUnderTest = MenuDrawerViewController(contentViewController: fromViewController, menuViewController: UIViewController())
+                    unitUnderTest = MenuDrawerViewController(menuViewController: MockMenuViewController())
                     unitUnderTest.fadeFrom(fromViewController, to: toViewController)
                 }
 

--- a/Tests/MockMenuDrawerViewController.swift
+++ b/Tests/MockMenuDrawerViewController.swift
@@ -1,6 +1,6 @@
 @testable import SKMenuDrawerViewController
 
-class MockMenuDrawerViewController: MenuDrawerViewController {
+class MockMenuDrawerViewController: MenuDrawerViewController<MockMenuViewController> {
     var addContentViewControllerCalled = false
     var fadeFromToCalled = false
 

--- a/Tests/MockMenuViewController.swift
+++ b/Tests/MockMenuViewController.swift
@@ -1,0 +1,11 @@
+@testable import SKMenuDrawerViewController
+
+class MockMenuViewController: UIViewController, MenuViewControllerProtocol {
+    var initialContentViewControllerCalled = false
+
+    func initialContentViewController() -> UIViewController {
+        initialContentViewControllerCalled = true
+
+        return UIViewController()
+    }
+}


### PR DESCRIPTION
- Addresses #13 
- Removes the need to provide a content view controller on init. This is handled by the menu view controller which now must conform to `MenuViewControllerProtocol`.