### PR TITLE
0.0.5 Release

### DIFF
--- a/SKMenuDrawerViewController.podspec
+++ b/SKMenuDrawerViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'SKMenuDrawerViewController'
-  spec.version = '0.0.4'
+  spec.version = '0.0.5'
   spec.license = 'MIT'
   spec.summary = 'A simple side menu view controller.'
   spec.homepage = 'https://github.com/skladek/SKMenuDrawerViewController'

--- a/SKMenuDrawerViewController.xcodeproj/project.pbxproj
+++ b/SKMenuDrawerViewController.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		14416D2D1F0D35A300E0065C /* SKMenuDrawerViewController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14416D231F0D35A300E0065C /* SKMenuDrawerViewController.framework */; };
 		14416D441F0D35C500E0065C /* SKMenuDrawerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 14416D3F1F0D35C500E0065C /* SKMenuDrawerViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		14D1EEC01F0FDCDC005781E4 /* MenuViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1EEBF1F0FDCDC005781E4 /* MenuViewControllerProtocol.swift */; };
+		14D1EEC21F0FDE27005781E4 /* MockMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1EEC11F0FDE27005781E4 /* MockMenuViewController.swift */; };
 		14F6923B1F0D4DB500564955 /* MenuDrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F6923A1F0D4DB500564955 /* MenuDrawerViewController.swift */; };
 		14F692B11F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F692B01F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift */; };
 		14F692B31F0DB66700564955 /* MockMenuDrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F692B21F0DB66700564955 /* MockMenuDrawerViewController.swift */; };
@@ -35,6 +37,8 @@
 		14416D3E1F0D35C500E0065C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14416D3F1F0D35C500E0065C /* SKMenuDrawerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKMenuDrawerViewController.h; sourceTree = "<group>"; };
 		14416D411F0D35C500E0065C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		14D1EEBF1F0FDCDC005781E4 /* MenuViewControllerProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewControllerProtocol.swift; sourceTree = "<group>"; };
+		14D1EEC11F0FDE27005781E4 /* MockMenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMenuViewController.swift; sourceTree = "<group>"; };
 		14F6923A1F0D4DB500564955 /* MenuDrawerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuDrawerViewController.swift; sourceTree = "<group>"; };
 		14F692B01F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuDrawerViewControllerSpec.swift; sourceTree = "<group>"; };
 		14F692B21F0DB66700564955 /* MockMenuDrawerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMenuDrawerViewController.swift; sourceTree = "<group>"; };
@@ -104,6 +108,7 @@
 			children = (
 				14416D3E1F0D35C500E0065C /* Info.plist */,
 				14F6923A1F0D4DB500564955 /* MenuDrawerViewController.swift */,
+				14D1EEBF1F0FDCDC005781E4 /* MenuViewControllerProtocol.swift */,
 				14416D3F1F0D35C500E0065C /* SKMenuDrawerViewController.h */,
 				14F692C41F0E87D400564955 /* UIViewController.swift */,
 			);
@@ -116,6 +121,7 @@
 				14416D411F0D35C500E0065C /* Info.plist */,
 				14F692B01F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift */,
 				14F692B21F0DB66700564955 /* MockMenuDrawerViewController.swift */,
+				14D1EEC11F0FDE27005781E4 /* MockMenuViewController.swift */,
 				14F692C91F0E8D3A00564955 /* MockUIViewController.swift */,
 				14F692C71F0E8CF100564955 /* UIViewControllerSpec.swift */,
 			);
@@ -345,6 +351,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14F6923B1F0D4DB500564955 /* MenuDrawerViewController.swift in Sources */,
+				14D1EEC01F0FDCDC005781E4 /* MenuViewControllerProtocol.swift in Sources */,
 				14F692C51F0E87D400564955 /* UIViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -357,6 +364,7 @@
 				14F692CB1F0E8D3E00564955 /* UIViewControllerSpec.swift in Sources */,
 				14F692CA1F0E8D3A00564955 /* MockUIViewController.swift in Sources */,
 				14F692B11F0DADAC00564955 /* MenuDrawerViewControllerSpec.swift in Sources */,
+				14D1EEC21F0FDE27005781E4 /* MockMenuViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14D1EEBA1F0F50EB005781E4 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1EEB91F0F50EB005781E4 /* NavigationController.swift */; };
 		14F692811F0D4EE300564955 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F692781F0D4EE300564955 /* AppDelegate.swift */; };
 		14F692821F0D4EE300564955 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14F692791F0D4EE300564955 /* Assets.xcassets */; };
 		14F692831F0D4EE300564955 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 14F6927A1F0D4EE300564955 /* LaunchScreen.storyboard */; };
@@ -58,6 +59,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		14D1EEB91F0F50EB005781E4 /* NavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
 		14F692451F0D4E8A00564955 /* SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		14F692781F0D4EE300564955 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		14F692791F0D4EE300564955 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 				14F692B41F0DBEA000564955 /* ContentViewController.xib */,
 				14F6929C1F0D54A400564955 /* MenuViewController.swift */,
 				14F692AE1F0D6DE200564955 /* MenuViewController.xib */,
+				14D1EEB91F0F50EB005781E4 /* NavigationController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14F6929D1F0D54A400564955 /* MenuViewController.swift in Sources */,
+				14D1EEBA1F0F50EB005781E4 /* NavigationController.swift in Sources */,
 				14F692A71F0D653E00564955 /* ContentViewController.swift in Sources */,
 				14F692811F0D4EE300564955 /* AppDelegate.swift in Sources */,
 			);

--- a/SampleApp/SampleApp/Application/AppDelegate.swift
+++ b/SampleApp/SampleApp/Application/AppDelegate.swift
@@ -8,9 +8,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        let contentViewController = ContentViewController(color: .red)
+        let contentViewController = ContentViewController()
+        let contentNavigationController = NavigationController(rootViewController: contentViewController)
         let menuViewController = MenuViewController()
-        let rootViewController = MenuDrawerViewController(contentViewController: contentViewController, menuViewController: menuViewController)
+        let menuNavigationController = UINavigationController(rootViewController: menuViewController)
+        let rootViewController = MenuDrawerViewController(contentViewController: contentNavigationController, menuViewController: menuNavigationController)
         self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()
 

--- a/SampleApp/SampleApp/Application/AppDelegate.swift
+++ b/SampleApp/SampleApp/Application/AppDelegate.swift
@@ -8,11 +8,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        let contentViewController = ContentViewController()
-        let contentNavigationController = NavigationController(rootViewController: contentViewController)
         let menuViewController = MenuViewController()
-        let menuNavigationController = UINavigationController(rootViewController: menuViewController)
-        let rootViewController = MenuDrawerViewController(contentViewController: contentNavigationController, menuViewController: menuNavigationController)
+        let rootViewController = MenuDrawerViewController(menuViewController: menuViewController)
         self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()
 

--- a/SampleApp/SampleApp/ViewControllers/ContentViewController.swift
+++ b/SampleApp/SampleApp/ViewControllers/ContentViewController.swift
@@ -1,49 +1,21 @@
 import Foundation
-import SKMenuDrawerViewController
+import SKTableViewDataSource
 import UIKit
 
 class ContentViewController: UIViewController {
+    var dataSource: TableViewDataSource<String>?
 
-    enum Color: Int {
-        case red = 0
-        case green
-        case blue
-    }
+    let jobs = ["Content Row 1", "Content Row 2", "Content Row 3", "Content Row 4", "Content Row 5"]
 
-    let color: Color
-
-    init(color: Color) {
-        self.color = color
-
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func backgroundColor(for color: Color) -> UIColor {
-        var backgroundColor = UIColor.white
-
-        switch color {
-        case .blue:
-            backgroundColor = .blue
-        case .green:
-            backgroundColor = .green
-        case .red:
-            backgroundColor = .red
-        }
-
-        return backgroundColor
-    }
-
-    @IBAction func menuButtonTapped() {
-        parent?.toggleMenu()
-    }
+    @IBOutlet weak var tableView: UITableView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = backgroundColor(for: color)
+        dataSource = TableViewDataSource(objects: jobs, cell: UITableViewCell.self, cellPresenter: { (cell, object) in
+            cell.textLabel?.text = object
+        })
+
+        tableView.dataSource = dataSource
     }
 }

--- a/SampleApp/SampleApp/ViewControllers/ContentViewController.xib
+++ b/SampleApp/SampleApp/ViewControllers/ContentViewController.xib
@@ -11,6 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ContentViewController" customModule="SampleApp" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="XDn-vM-sGq" id="YFb-AX-OGD"/>
                 <outlet property="view" destination="yGM-6A-f5s" id="ciP-zV-acm"/>
             </connections>
         </placeholder>
@@ -19,22 +20,17 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UjA-0T-DMF">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XDn-vM-sGq">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                    <state key="normal" title="Toggle Menu">
-                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="menuButtonTapped" destination="-1" eventType="touchUpInside" id="Ooh-v5-DiE"/>
-                    </connections>
-                </button>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                </tableView>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="UjA-0T-DMF" secondAttribute="trailing" id="XNY-vX-Iik"/>
-                <constraint firstItem="UjA-0T-DMF" firstAttribute="leading" secondItem="yGM-6A-f5s" secondAttribute="leading" id="XZp-zR-iM6"/>
-                <constraint firstItem="UjA-0T-DMF" firstAttribute="top" secondItem="yGM-6A-f5s" secondAttribute="top" id="nkZ-T4-Tlf"/>
-                <constraint firstAttribute="bottom" secondItem="UjA-0T-DMF" secondAttribute="bottom" id="xr9-rK-fwj"/>
+                <constraint firstItem="XDn-vM-sGq" firstAttribute="leading" secondItem="yGM-6A-f5s" secondAttribute="leading" id="BJQ-Qz-X23"/>
+                <constraint firstAttribute="bottom" secondItem="XDn-vM-sGq" secondAttribute="bottom" id="Ecb-l9-pdR"/>
+                <constraint firstItem="XDn-vM-sGq" firstAttribute="top" secondItem="yGM-6A-f5s" secondAttribute="top" id="Tvo-SU-k5d"/>
+                <constraint firstAttribute="trailing" secondItem="XDn-vM-sGq" secondAttribute="trailing" id="bEF-qa-3JI"/>
             </constraints>
             <point key="canvasLocation" x="-60" y="-26"/>
         </view>

--- a/SampleApp/SampleApp/ViewControllers/MenuViewController.swift
+++ b/SampleApp/SampleApp/ViewControllers/MenuViewController.swift
@@ -1,11 +1,25 @@
 import Foundation
+import SKMenuDrawerViewController
 import SKTableViewDataSource
 import UIKit
 
-class MenuViewController: UIViewController {
+class MenuViewController: UIViewController, MenuViewControllerProtocol {
 
     var dataSource: TableViewDataSource<String>?
     @IBOutlet weak var tableView: UITableView!
+
+    func initialContentViewController() -> UIViewController {
+        let indexPath = IndexPath(row: 0, section: 0)
+
+        return viewControllerForIndexPath(indexPath)
+    }
+
+    func viewControllerForIndexPath(_ indexPath: IndexPath) -> UIViewController {
+        let viewController = ContentViewController()
+        let navigationController = NavigationController(rootViewController: viewController)
+
+        return navigationController
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,10 +36,8 @@ class MenuViewController: UIViewController {
 
 extension MenuViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let viewController = ContentViewController()
-        let navigationController = NavigationController(rootViewController: viewController)
+        let navigationController = viewControllerForIndexPath(indexPath)
         parent?.setRootContentViewController(navigationController)
-
         parent?.toggleMenu()
     }
 }

--- a/SampleApp/SampleApp/ViewControllers/MenuViewController.swift
+++ b/SampleApp/SampleApp/ViewControllers/MenuViewController.swift
@@ -1,31 +1,19 @@
 import Foundation
-import SKMenuDrawerViewController
 import SKTableViewDataSource
 import UIKit
 
 class MenuViewController: UIViewController {
 
-    var dataSource: TableViewDataSource<ContentViewController.Color>?
+    var dataSource: TableViewDataSource<String>?
     @IBOutlet weak var tableView: UITableView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let colors: [ContentViewController.Color] = [.red, .green, .blue]
+        let options = ["Option 1", "Option 2", "Option 3", "Option 4", "Option 5"]
 
-        dataSource = TableViewDataSource(objects: colors, cell: UITableViewCell.self) { (cell, color) in
-            var title: String? = nil
-
-            switch color {
-            case .blue:
-                title = "Blue"
-            case .green:
-                title = "Green"
-            case .red:
-                title = "Red"
-            }
-
-            cell.textLabel?.text = title
+        dataSource = TableViewDataSource(objects: options, cell: UITableViewCell.self) { (cell, object) in
+            cell.textLabel?.text = object
         }
 
         tableView.dataSource = dataSource
@@ -34,14 +22,9 @@ class MenuViewController: UIViewController {
 
 extension MenuViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let color = ContentViewController.Color(rawValue: indexPath.row),
-            let parentViewController = parent as? MenuDrawerViewController else {
-                return
-        }
-
-        let viewController = ContentViewController(color: color)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        parentViewController.setRootContentViewController(navigationController)
+        let viewController = ContentViewController()
+        let navigationController = NavigationController(rootViewController: viewController)
+        parent?.setRootContentViewController(navigationController)
 
         parent?.toggleMenu()
     }

--- a/SampleApp/SampleApp/ViewControllers/MenuViewController.xib
+++ b/SampleApp/SampleApp/ViewControllers/MenuViewController.xib
@@ -21,21 +21,30 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="26L-6j-kMb">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="bQD-3f-cuZ"/>
                     </connections>
                 </tableView>
+                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dCO-av-6GN">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                    <items>
+                        <navigationItem id="6tb-Nk-K9S"/>
+                    </items>
+                </navigationBar>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="26L-6j-kMb" firstAttribute="top" secondItem="JwL-2s-Gac" secondAttribute="top" id="KXS-dQ-ZvC"/>
+                <constraint firstItem="dCO-av-6GN" firstAttribute="leading" secondItem="JwL-2s-Gac" secondAttribute="leading" id="3q7-gH-wq3"/>
+                <constraint firstAttribute="trailing" secondItem="dCO-av-6GN" secondAttribute="trailing" id="Go4-xb-eC9"/>
                 <constraint firstItem="26L-6j-kMb" firstAttribute="leading" secondItem="JwL-2s-Gac" secondAttribute="leading" id="MyG-Gs-jiL"/>
                 <constraint firstAttribute="trailing" secondItem="26L-6j-kMb" secondAttribute="trailing" id="PoQ-lN-DWc"/>
                 <constraint firstAttribute="bottom" secondItem="26L-6j-kMb" secondAttribute="bottom" id="cOr-gw-Cqf"/>
+                <constraint firstItem="26L-6j-kMb" firstAttribute="top" secondItem="dCO-av-6GN" secondAttribute="bottom" id="oDh-XH-Kct"/>
+                <constraint firstItem="dCO-av-6GN" firstAttribute="top" secondItem="JwL-2s-Gac" secondAttribute="top" id="v5W-kw-E6u"/>
             </constraints>
-            <point key="canvasLocation" x="-86" y="-185"/>
+            <point key="canvasLocation" x="-86.5" y="-185.5"/>
         </view>
     </objects>
 </document>

--- a/SampleApp/SampleApp/ViewControllers/NavigationController.swift
+++ b/SampleApp/SampleApp/ViewControllers/NavigationController.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+class NavigationController: UINavigationController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        delegate = self
+    }
+}
+
+extension NavigationController: UINavigationControllerDelegate {
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        if navigationController.viewControllers.count == 1 {
+            let barItem = UIBarButtonItem(title: "Menu", style: .plain, target: parent, action: #selector(toggleMenu))
+            viewController.navigationItem.leftBarButtonItem = barItem
+        }
+    }
+}

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Source/MenuDrawerViewController.swift
+++ b/Source/MenuDrawerViewController.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-open class MenuDrawerViewController: UIViewController {
+open class MenuDrawerViewController<T: UIViewController>: UIViewController where T: MenuViewControllerProtocol {
 
     // MARK: Static Variables
 
-    static let animationDuration = 0.25
+    let animationDuration = 0.25
 
-    static let menuWidthPercentage: CGFloat = 0.75
+    let menuWidthPercentage: CGFloat = 0.75
 
     // MARK: Internal Variables
 
@@ -24,8 +24,8 @@ open class MenuDrawerViewController: UIViewController {
 
     // MARK: Initializers
 
-    public init(contentViewController: UIViewController, menuViewController: UIViewController) {
-        self.contentViewController = contentViewController
+    public init(menuViewController: T) {
+        self.contentViewController = menuViewController.initialContentViewController()
         self.menuViewController = menuViewController
 
         super.init(nibName: nil, bundle: nil)
@@ -44,7 +44,7 @@ open class MenuDrawerViewController: UIViewController {
 
     open override func toggleMenu() {
         menuIsOpen = !menuIsOpen
-        let duration = MenuDrawerViewController.animationDuration
+        let duration = animationDuration
         animateBackgroundDim(duration: duration)
         view.setNeedsLayout()
 
@@ -98,7 +98,7 @@ open class MenuDrawerViewController: UIViewController {
     }
 
     func fadeFrom(_ fromViewController: UIViewController, to toViewController: UIViewController) {
-        UIView.animate(withDuration: MenuDrawerViewController.animationDuration, animations: {
+        UIView.animate(withDuration: animationDuration, animations: {
             fromViewController.view.alpha = 0.0
         }) { [weak self] (_) in
             fromViewController.view.removeFromSuperview()
@@ -109,7 +109,7 @@ open class MenuDrawerViewController: UIViewController {
     }
 
     func menuWidth() -> CGFloat {
-        return ceil(view.frame.width * MenuDrawerViewController.menuWidthPercentage)
+        return ceil(view.frame.width * menuWidthPercentage)
     }
 
     // MARK: UIViewController Methods

--- a/Source/MenuDrawerViewController.swift
+++ b/Source/MenuDrawerViewController.swift
@@ -2,15 +2,15 @@ import Foundation
 
 open class MenuDrawerViewController: UIViewController {
 
-    static let animationDuration = 0.33
+    static let animationDuration = 0.25
 
     static let menuWidthPercentage: CGFloat = 0.75
-
-    static let springDampening: CGFloat = 0.6
 
     let backgroundDim = UIControl()
 
     var contentViewController: UIViewController
+
+    var menuLeftConstraint: NSLayoutConstraint?
 
     var menuRightConstraint: NSLayoutConstraint?
 
@@ -42,7 +42,7 @@ open class MenuDrawerViewController: UIViewController {
 
         animateBackgroundDim(duration: duration, intoView: animateIntoView)
 
-        UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: MenuDrawerViewController.springDampening, initialSpringVelocity: 0, options: [], animations: {
+        UIView.animate(withDuration: duration, delay: 0.0, options: .curveEaseInOut, animations: {
             self.view.layoutIfNeeded()
         }, completion: nil)
     }
@@ -60,12 +60,9 @@ open class MenuDrawerViewController: UIViewController {
         view.addSubview(viewController.view)
         view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[menuView]|", options: [], metrics: nil, views: ["menuView": viewController.view]))
 
-        let widthConstraint = NSLayoutConstraint(item: viewController.view, attribute: .width, relatedBy: .equal, toItem: view, attribute: .width, multiplier: MenuDrawerViewController.menuWidthPercentage, constant: 0)
-        widthConstraint.priority = UILayoutPriorityDefaultHigh
-        view.addConstraint(widthConstraint)
-
-        let leftConstraint = NSLayoutConstraint(item: viewController.view, attribute: .left, relatedBy: .equal, toItem: view, attribute: .left, multiplier: 1, constant: 0)
+        let leftConstraint = NSLayoutConstraint(item: viewController.view, attribute: .left, relatedBy: .equal, toItem: view, attribute: .left, multiplier: 1, constant: -menuWidth())
         view.addConstraint(leftConstraint)
+        menuLeftConstraint = leftConstraint
 
         let menuConstraint = NSLayoutConstraint(item: viewController.view, attribute: .right, relatedBy: .equal, toItem: view, attribute: .left, multiplier: 1, constant: 0)
         view.addConstraint(menuConstraint)
@@ -103,11 +100,26 @@ open class MenuDrawerViewController: UIViewController {
         }
     }
 
+    func menuWidth() -> CGFloat {
+        return ceil(view.frame.width * MenuDrawerViewController.menuWidthPercentage)
+    }
+
     open override func viewDidLoad() {
         super.viewDidLoad()
 
         addContentViewController(contentViewController)
         addMenuViewController(menuViewController)
         addBackgroundDim()
+    }
+
+    open override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        let menuIsClosed = (menuRightConstraint?.constant == 0)
+        let width = menuWidth()
+        let leftConstant = (menuIsClosed) ? -width : 0
+        let rightConstant = (menuIsClosed) ? 0 : width
+        menuLeftConstraint?.constant = leftConstant
+        menuRightConstraint?.constant = rightConstant
     }
 }

--- a/Source/MenuDrawerViewController.swift
+++ b/Source/MenuDrawerViewController.swift
@@ -2,19 +2,27 @@ import Foundation
 
 open class MenuDrawerViewController: UIViewController {
 
+    // MARK: Static Variables
+
     static let animationDuration = 0.25
 
     static let menuWidthPercentage: CGFloat = 0.75
 
+    // MARK: Internal Variables
+
     let backgroundDim = UIControl()
 
     var contentViewController: UIViewController
+
+    var menuIsOpen = false
 
     var menuLeftConstraint: NSLayoutConstraint?
 
     var menuRightConstraint: NSLayoutConstraint?
 
     let menuViewController: UIViewController
+
+    // MARK: Initializers
 
     public init(contentViewController: UIViewController, menuViewController: UIViewController) {
         self.contentViewController = contentViewController
@@ -27,25 +35,25 @@ open class MenuDrawerViewController: UIViewController {
         return nil
     }
 
+    // MARK: Public Methods
+
     open override func setRootContentViewController(_ viewController: UIViewController) {
         addContentViewController(viewController)
         fadeFrom(contentViewController, to: viewController)
     }
 
     open override func toggleMenu() {
-        let animateIntoView = (menuRightConstraint?.constant == 0)
-
-        let menuOffset = (animateIntoView) ? ceil(view.frame.width * 0.75) : 0
-        menuRightConstraint?.constant = menuOffset
-
+        menuIsOpen = !menuIsOpen
         let duration = MenuDrawerViewController.animationDuration
-
-        animateBackgroundDim(duration: duration, intoView: animateIntoView)
+        animateBackgroundDim(duration: duration)
+        view.setNeedsLayout()
 
         UIView.animate(withDuration: duration, delay: 0.0, options: .curveEaseInOut, animations: {
             self.view.layoutIfNeeded()
         }, completion: nil)
     }
+
+    // MARK: Internal Methods
 
     func addContentViewController(_ viewController: UIViewController) {
         addChildViewController(viewController)
@@ -81,8 +89,8 @@ open class MenuDrawerViewController: UIViewController {
         backgroundDim.addTarget(self, action: #selector(toggleMenu), for: .touchUpInside)
     }
 
-    func animateBackgroundDim(duration: TimeInterval, intoView: Bool) {
-        let endingAlpha: CGFloat = (intoView) ? 1.0 : 0.0
+    func animateBackgroundDim(duration: TimeInterval) {
+        let endingAlpha: CGFloat = (menuIsOpen) ? 1.0 : 0.0
 
         UIView.animate(withDuration: duration) {
             self.backgroundDim.alpha = endingAlpha
@@ -104,6 +112,8 @@ open class MenuDrawerViewController: UIViewController {
         return ceil(view.frame.width * MenuDrawerViewController.menuWidthPercentage)
     }
 
+    // MARK: UIViewController Methods
+
     open override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -115,10 +125,9 @@ open class MenuDrawerViewController: UIViewController {
     open override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
 
-        let menuIsClosed = (menuRightConstraint?.constant == 0)
         let width = menuWidth()
-        let leftConstant = (menuIsClosed) ? -width : 0
-        let rightConstant = (menuIsClosed) ? 0 : width
+        let leftConstant = (menuIsOpen) ? 0 : -width
+        let rightConstant = (menuIsOpen) ? width : 0
         menuLeftConstraint?.constant = leftConstant
         menuRightConstraint?.constant = rightConstant
     }

--- a/Source/MenuDrawerViewController.swift
+++ b/Source/MenuDrawerViewController.swift
@@ -50,6 +50,7 @@ open class MenuDrawerViewController: UIViewController {
     func addContentViewController(_ viewController: UIViewController) {
         addChildViewController(viewController)
         view.insertSubview(viewController.view, at: 0)
+        view.layoutIfNeeded()
         viewController.didMove(toParentViewController: self)
     }
 

--- a/Source/MenuViewControllerProtocol.swift
+++ b/Source/MenuViewControllerProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol MenuViewControllerProtocol {
+    func initialContentViewController() -> UIViewController
+}

--- a/Tests/MenuDrawerViewControllerSpec.swift
+++ b/Tests/MenuDrawerViewControllerSpec.swift
@@ -6,25 +6,23 @@ import Quick
 
 class MenuDrawerViewControllerSpec: QuickSpec {
     override func spec() {
-        var unitUnderTest: MenuDrawerViewController!
+        var unitUnderTest: MenuDrawerViewController<MockMenuViewController>!
 
         describe("MenuDrawerViewController") {
             context("init(contentViewController:menuViewController:)") {
-                var contentViewController: UIViewController!
-                var menuViewController: UIViewController!
+                var menuViewController: MockMenuViewController!
 
                 beforeEach {
-                    contentViewController = UIViewController()
-                    menuViewController = UIViewController()
-                    unitUnderTest = MenuDrawerViewController(contentViewController: contentViewController, menuViewController: menuViewController)
-                }
-
-                it("Should set the content view controller") {
-                    expect(unitUnderTest.contentViewController).to(be(contentViewController))
+                    menuViewController = MockMenuViewController()
+                    unitUnderTest = MenuDrawerViewController(menuViewController: menuViewController)
                 }
 
                 it("Should set the menu view controller") {
                     expect(unitUnderTest.menuViewController).to(be(menuViewController))
+                }
+
+                it("Should call initialContentViewController on the menu view controller") {
+                    expect(menuViewController.initialContentViewControllerCalled).to(beTrue())
                 }
             }
 
@@ -41,7 +39,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
 
             context("setRootContentViewController(_:)") {
                 beforeEach {
-                    unitUnderTest = MockMenuDrawerViewController(contentViewController: UIViewController(), menuViewController: UIViewController())
+                    unitUnderTest = MockMenuDrawerViewController(menuViewController: MockMenuViewController())
                     unitUnderTest.setRootContentViewController(UIViewController())
                 }
 
@@ -55,11 +53,11 @@ class MenuDrawerViewControllerSpec: QuickSpec {
             }
 
             context("toggleMenu()") {
-                var menuViewController: UIViewController!
+                var menuViewController: MockMenuViewController!
 
                 beforeEach {
-                    menuViewController = UIViewController()
-                    unitUnderTest = MenuDrawerViewController(contentViewController: UIViewController(), menuViewController: menuViewController)
+                    menuViewController = MockMenuViewController()
+                    unitUnderTest = MenuDrawerViewController(menuViewController: menuViewController)
                     expect(unitUnderTest.view).toNot(beNil())
                     unitUnderTest.viewDidLoad()
                     unitUnderTest.view.layoutIfNeeded()
@@ -76,7 +74,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
                 var viewController: UIViewController!
 
                 beforeEach {
-                    unitUnderTest = MenuDrawerViewController(contentViewController: UIViewController(), menuViewController: UIViewController())
+                    unitUnderTest = MenuDrawerViewController(menuViewController: MockMenuViewController())
                     viewController = UIViewController()
                     unitUnderTest.addContentViewController(viewController)
                 }
@@ -94,7 +92,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
                 var viewController: UIViewController!
 
                 beforeEach {
-                    unitUnderTest = MenuDrawerViewController(contentViewController: UIViewController(), menuViewController: UIViewController())
+                    unitUnderTest = MenuDrawerViewController(menuViewController: MockMenuViewController())
                     viewController = UIViewController()
                     unitUnderTest.addMenuViewController(viewController)
                 }
@@ -115,7 +113,7 @@ class MenuDrawerViewControllerSpec: QuickSpec {
                 beforeEach {
                     fromViewController = UIViewController()
                     toViewController = UIViewController()
-                    unitUnderTest = MenuDrawerViewController(contentViewController: fromViewController, menuViewController: UIViewController())
+                    unitUnderTest = MenuDrawerViewController(menuViewController: MockMenuViewController())
                     unitUnderTest.fadeFrom(fromViewController, to: toViewController)
                 }
 

--- a/Tests/MockMenuDrawerViewController.swift
+++ b/Tests/MockMenuDrawerViewController.swift
@@ -1,6 +1,6 @@
 @testable import SKMenuDrawerViewController
 
-class MockMenuDrawerViewController: MenuDrawerViewController {
+class MockMenuDrawerViewController: MenuDrawerViewController<MockMenuViewController> {
     var addContentViewControllerCalled = false
     var fadeFromToCalled = false
 

--- a/Tests/MockMenuViewController.swift
+++ b/Tests/MockMenuViewController.swift
@@ -1,0 +1,11 @@
+@testable import SKMenuDrawerViewController
+
+class MockMenuViewController: UIViewController, MenuViewControllerProtocol {
+    var initialContentViewControllerCalled = false
+
+    func initialContentViewController() -> UIViewController {
+        initialContentViewControllerCalled = true
+
+        return UIViewController()
+    }
+}


### PR DESCRIPTION
- Removed the need to provide a content view controller on init. This is handled by the menu view controller which now must conform to `MenuViewControllerProtocol`.
- Cleaned up the menu close animation to prevent the menu view from resizing during animation. This removed the spring animation for now.
- Code cleanup around how the menu open/closed state was calculated.
- Fixed an issue causing the content to shift as the menu view was animating out.